### PR TITLE
Feat/saved builder state

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ repositories {
 }
 
 def runeLiteVersion = 'latest.release'
-def pluginMainClass = 'dev.hollink.partytrails.TreasureTrailPlugin'
+def pluginMainClass = 'dev.hollink.partytrails.PartyTrailsPlugin'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
@@ -41,6 +41,14 @@ tasks.register('run', JavaExec) {
 
 	jvmArgs "-ea"
 	args "--developer-mode", "--debug"
+}
+
+tasks.register('runTest', JavaExec) {
+    classpath = sourceSets.test.runtimeClasspath
+    mainClass = pluginMainClass + "Test"
+
+    jvmArgs "-ea"
+    args "--developer-mode", "--debug"
 }
 
 tasks.register('shadowJar', Jar) {

--- a/src/main/java/dev/hollink/partytrails/PartyTrailsConfig.java
+++ b/src/main/java/dev/hollink/partytrails/PartyTrailsConfig.java
@@ -4,6 +4,7 @@ import static dev.hollink.partytrails.PartyTrailsConfig.CONFIG_GROUP;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
 
 @ConfigGroup(CONFIG_GROUP)
 public interface PartyTrailsConfig extends Config
@@ -12,18 +13,21 @@ public interface PartyTrailsConfig extends Config
 
 	String TREASURE_TRAIL = "TreasureTrail";
 	String TREASURE_TRAIL_PROGRESS = "TreasureTrailProgress";
+	String SHOW_BUILDER_OVERLAY = "ShowBuilderOverlay";
+	String BUILDER_STATE = "SavedBuilderState";
 
-	//	@ConfigSection(
-//		name = "Player",
-//		description = "Player configuration",
-//		position = 0
-//	)
-	String player = "player";
+	@ConfigSection(
+		name = "Player",
+		description = "Player trail configuration",
+		position = 0
+	)
+	String player = "Player";
 
 	@ConfigItem(
 		keyName = TREASURE_TRAIL,
 		name = "Active Treasure Trail",
 		description = "Encoded treasure trail string from the clue builder panel.",
+		position = 0,
 		section = player
 	)
 	default String trailString()
@@ -38,6 +42,35 @@ public interface PartyTrailsConfig extends Config
 		section = player,
 		hidden = true)
 	default String trailProgress()
+	{
+		return "";
+	}
+
+	@ConfigSection(
+		name = "Builder",
+		description = "Builder configuration",
+		position = 1
+	)
+	String builder = "Builder";
+
+	@ConfigItem(
+		keyName = SHOW_BUILDER_OVERLAY,
+		name = "Highlight targets & tiles",
+		description = "Show the targeted tiles, NPCs and areas marked inside the trail builder.",
+		position = 0,
+		section = builder)
+	default boolean showBuilderOverlay()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = BUILDER_STATE,
+		name = "Builder save",
+		description = "Saved form state from the clue builder.",
+		position = 1,
+		section = builder)
+	default String builderState()
 	{
 		return "";
 	}

--- a/src/main/java/dev/hollink/partytrails/PartyTrailsPlugin.java
+++ b/src/main/java/dev/hollink/partytrails/PartyTrailsPlugin.java
@@ -2,8 +2,8 @@ package dev.hollink.partytrails;
 
 import com.google.inject.Provides;
 import dev.hollink.partytrails.builder.TrailBuilderPanel;
-import dev.hollink.partytrails.data.events.TrailEvent;
 import dev.hollink.partytrails.data.events.ClueEventFactory;
+import dev.hollink.partytrails.data.events.TrailEvent;
 import dev.hollink.partytrails.data.steps.TrailStep;
 import dev.hollink.partytrails.data.trail.TrailContext;
 import dev.hollink.partytrails.runetime.TrailEventBus;
@@ -13,7 +13,9 @@ import java.awt.image.BufferedImage;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
+import net.runelite.api.GameState;
 import net.runelite.api.events.AnimationChanged;
+import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.events.StatChanged;
 import net.runelite.client.config.ConfigManager;
@@ -78,6 +80,7 @@ public class PartyTrailsPlugin extends Plugin
 	private TrailEventBus clueEventBus;
 
 	private NavigationButton navButton;
+	private TrailBuilderPanel builderPanel;
 
 	@Override
 	protected void startUp() throws Exception
@@ -95,6 +98,18 @@ public class PartyTrailsPlugin extends Plugin
 		trailManager.stop();
 		clientToolbar.removeNavigation(navButton);
 		log.debug("Treasure Trail plugin stopped");
+	}
+
+	@Subscribe
+	public void onGameStateChanged(GameStateChanged gameStateChanged)
+	{
+		log.debug("Game state changed: {}", gameStateChanged);
+		if (gameStateChanged.getGameState() == GameState.LOGGED_IN)
+		{
+			builderPanel.enableTrailBuilder();
+		} else {
+			builderPanel.disableTrailBuilder();
+		}
 	}
 
 	@Subscribe
@@ -166,7 +181,7 @@ public class PartyTrailsPlugin extends Plugin
 
 	private void addTrailBuilderPanel()
 	{
-		TrailBuilderPanel builderPanel = new TrailBuilderPanel(client, clueEventBus);
+		builderPanel = new TrailBuilderPanel(client, configManager, clueEventBus);
 
 		BufferedImage icon = ImageUtil.loadImageResource(getClass(), "/icon.png");
 		navButton = NavigationButton.builder()

--- a/src/main/java/dev/hollink/partytrails/builder/StepEditorPanel.java
+++ b/src/main/java/dev/hollink/partytrails/builder/StepEditorPanel.java
@@ -20,20 +20,24 @@ import lombok.extern.slf4j.Slf4j;
 public final class StepEditorPanel extends JPanel implements FormHelper
 {
 	private final TrailEventBus clueEventBus;
+	private final Consumer<StepEditorPanel> deleteCallback;
+	private final Runnable updateCallback;
 
 	private final JComboBox<StepType> typeSelect = new JComboBox<>(StepType.values());
-
-	private int stepNumber = 1;
 	private StepEditor currentStepEditor;
+	private int stepNumber = 1;
 
 	public StepEditorPanel(TrailEventBus clueEventBus, Consumer<StepEditorPanel> deleteCallback, Runnable updateCallback)
 	{
 		this.clueEventBus = clueEventBus;
+		this.deleteCallback = deleteCallback;
+		this.updateCallback = updateCallback;
+
 		setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
 		setBorder(BorderFactory.createLineBorder(Color.GRAY));
-		buildEditor(deleteCallback, updateCallback);
+		buildEditor();
 
-		typeSelect.addActionListener(e -> rebuildEditor(deleteCallback, updateCallback));
+		typeSelect.addActionListener(e -> rebuildEditor());
 	}
 
 	public void setStepNumber(int number)
@@ -42,7 +46,7 @@ public final class StepEditorPanel extends JPanel implements FormHelper
 		setBorder(BorderFactory.createTitledBorder("Step " + number));
 	}
 
-	private void buildEditor(Consumer<StepEditorPanel> deleteCallback, Runnable updateCallback)
+	private void buildEditor()
 	{
 		add(createRow(typeSelect));
 
@@ -63,14 +67,14 @@ public final class StepEditorPanel extends JPanel implements FormHelper
 		updateCallback.run();
 	}
 
-	private void rebuildEditor(Consumer<StepEditorPanel> deleteCallback, Runnable updateCallback)
+	private void rebuildEditor()
 	{
 		if (currentStepEditor != null)
 		{
 			clueEventBus.unregister(currentStepEditor::onEvent);
 		}
 		removeAll();
-		buildEditor(deleteCallback, updateCallback);
+		buildEditor();
 	}
 
 	public List<StepEditorValidationError> getValidationErrors()
@@ -81,5 +85,11 @@ public final class StepEditorPanel extends JPanel implements FormHelper
 	public TrailStep toTrailStep()
 	{
 		return currentStepEditor.toTrailStep();
+	}
+
+	public void reloadTrailStep(int index, TrailStep trailStep) {
+		typeSelect.setSelectedItem(trailStep.type());
+		rebuildEditor();
+		currentStepEditor.setTrailStep(trailStep);
 	}
 }

--- a/src/main/java/dev/hollink/partytrails/builder/TrailBuilderPanel.java
+++ b/src/main/java/dev/hollink/partytrails/builder/TrailBuilderPanel.java
@@ -1,20 +1,25 @@
 package dev.hollink.partytrails.builder;
 
+import com.formdev.flatlaf.ui.FlatButtonBorder;
+import dev.hollink.partytrails.PartyTrailsConfig;
 import dev.hollink.partytrails.builder.editors.StepEditorValidationError;
 import dev.hollink.partytrails.data.TreasureTrail;
 import dev.hollink.partytrails.data.steps.TrailStep;
+import dev.hollink.partytrails.encoding.TrailDecoder;
 import dev.hollink.partytrails.encoding.TrailEncoder;
 import dev.hollink.partytrails.runetime.TrailEventBus;
 import dev.hollink.partytrails.utils.RandomUtil;
 import java.awt.BorderLayout;
+import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Toolkit;
 import java.awt.datatransfer.StringSelection;
+import java.awt.event.ActionListener;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Set;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
@@ -25,11 +30,14 @@ import javax.swing.JScrollPane;
 import javax.swing.JTextField;
 import javax.swing.ScrollPaneConstants;
 import net.runelite.api.Client;
+import net.runelite.client.config.ConfigManager;
 import net.runelite.client.ui.PluginPanel;
+import net.runelite.client.ui.components.PluginErrorPanel;
 
 public final class TrailBuilderPanel extends PluginPanel implements FormHelper
 {
 	private final Client client;
+	private final ConfigManager config;
 	private final TrailEventBus clueEventBus;
 
 	private final JTextField nameField = new JTextField();
@@ -37,31 +45,41 @@ public final class TrailBuilderPanel extends PluginPanel implements FormHelper
 	private final JPanel stepsContainer = new JPanel();
 	private final List<StepEditorPanel> editors = new ArrayList<>();
 
-	public TrailBuilderPanel(Client client, TrailEventBus clueEventBus)
+	private final JScrollPane scrollPane;
+
+	public TrailBuilderPanel(Client client, ConfigManager config, TrailEventBus clueEventBus)
 	{
 		this.client = client;
+		this.config = config;
 		this.clueEventBus = clueEventBus;
 
 		setLayout(new BorderLayout());
+		scrollPane = createForm();
 
-		JPanel form = new JPanel();
-		form.setLayout(new BoxLayout(form, BoxLayout.Y_AXIS));
+		// start disabled.
+		disableTrailBuilder();
+	}
 
-		addMetadataSection(form);
-		addStepsSection(form);
-		addButtons(form);
+	public void enableTrailBuilder()
+	{
+		removeAll();
 
-		// Start with a single step already present!
-		addStep();
-
-		JScrollPane scrollPane = new JScrollPane(form);
-		scrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
 		add(scrollPane, BorderLayout.CENTER);
 	}
 
+	public void disableTrailBuilder()
+	{
+		removeAll();
+
+		PluginErrorPanel pluginErrorPanel = new PluginErrorPanel();
+		pluginErrorPanel.setContent("Party Trails", "Sign in to start the builder.");
+		add(pluginErrorPanel);
+	}
 
 	private void addMetadataSection(JPanel form)
 	{
+		nameField.setMaximumSize(new Dimension(230, nameField.getPreferredSize().height));
+
 		form.add(createRow("Trail name", nameField));
 	}
 
@@ -69,7 +87,7 @@ public final class TrailBuilderPanel extends PluginPanel implements FormHelper
 	{
 		JButton addStep = new JButton("Add Step");
 		addStep.addActionListener(e -> addStep());
-		addStep.setMaximumSize(new Dimension(Integer.MAX_VALUE, addStep.getPreferredSize().height));
+		addStep.setMaximumSize(new Dimension(230, addStep.getPreferredSize().height));
 
 		stepsContainer.setLayout(new BoxLayout(stepsContainer, BoxLayout.Y_AXIS));
 		form.add(stepsContainer);
@@ -109,68 +127,45 @@ public final class TrailBuilderPanel extends PluginPanel implements FormHelper
 
 	private void addButtons(JPanel root)
 	{
-		root.add(Box.createVerticalStrut(8));
-
 		JButton encode = new JButton("Encode & Copy");
-		encode.setMaximumSize(new Dimension(Integer.MAX_VALUE, encode.getPreferredSize().height));
-		encode.addActionListener(e -> encodeTrail());
+		encode.setMaximumSize(new Dimension(230, encode.getPreferredSize().height));
+		encode.addActionListener(e -> encodeTrail(this::copyTrailToClipboard));
 
+		JButton save = getLoadSaveButton("Save", e -> encodeTrail(this::saveTrailToConfig));
+		JButton load = getLoadSaveButton("Load", e -> reloadSave());
+
+		root.add(Box.createVerticalStrut(16));
 		root.add(encode);
+		root.add(Box.createVerticalStrut(8));
+		root.add(save);
+		root.add(Box.createVerticalStrut(8));
+		root.add(load);
 	}
 
-	private void encodeTrail()
+	private JButton getLoadSaveButton(String text, ActionListener actionListener)
 	{
-		if (client.getLocalPlayer() == null)
+		JButton button = new JButton(text);
+		button.setMaximumSize(new Dimension(230, button.getPreferredSize().height));
+		button.addActionListener(actionListener);
+		FlatButtonBorder border = new FlatButtonBorder();
+		border.applyStyleProperty("borderColor", new Color(0, 0, 0, 0.05f));
+		button.setBackground(new Color(0, 0, 0, 0.05f));
+		button.setBorder(border);
+		return button;
+	}
+
+	private void encodeTrail(Consumer<String> callback)
+	{
+		if (showValidationErrors())
 		{
-			JOptionPane.showMessageDialog(this, "You must be logged in to encode a trail", "Error", JOptionPane.ERROR_MESSAGE);
 			return;
 		}
-
-		if (nameField.getText().isBlank())
-		{
-			JOptionPane.showMessageDialog(this, "Trail name required", "Error", JOptionPane.ERROR_MESSAGE);
-			return;
-		}
-
-		if (editors.isEmpty())
-		{
-			JOptionPane.showMessageDialog(this, "Add at least one step", "Error", JOptionPane.ERROR_MESSAGE);
-			return;
-		}
-
-		Set<StepEditorValidationError> errors = editors.stream()
-			.flatMap(editor -> editor.getValidationErrors().stream())
-			.collect(Collectors.toUnmodifiableSet());
-
-		if (!errors.isEmpty())
-		{
-			String message = errors.stream()
-				.sorted(Comparator.comparingInt(StepEditorValidationError::getStepIndex))
-				.map(error -> String.format("Step %d: %s", error.getStepIndex(), error.getErrorMessage()))
-				.collect(Collectors.joining("\n"));
-			JOptionPane.showMessageDialog(this, message, "Error", JOptionPane.ERROR_MESSAGE);
-			return;
-		}
-
-		List<TrailStep> steps = editors.stream()
-			.map(StepEditorPanel::toTrailStep)
-			.collect(Collectors.toList());
-
-		TreasureTrail trail = new TreasureTrail(
-			1,
-			RandomUtil.randomAlphanumeric(16),
-			nameField.getText(),
-			client.getLocalPlayer().getName(),
-			steps
-		);
 
 		try
 		{
+			TreasureTrail trail = generateTrailFromBuilderInput();
 			String encodeTrail = TrailEncoder.encodeTrail(trail);
-			Toolkit.getDefaultToolkit()
-				.getSystemClipboard()
-				.setContents(new StringSelection(encodeTrail), null);
-			JOptionPane.showMessageDialog(this, "Trail copied to clipboard");
+			callback.accept(encodeTrail);
 		}
 		catch (IOException e)
 		{
@@ -178,5 +173,142 @@ public final class TrailBuilderPanel extends PluginPanel implements FormHelper
 		}
 	}
 
+	private void copyTrailToClipboard(String encodeTrail)
+	{
+		Toolkit.getDefaultToolkit()
+			.getSystemClipboard()
+			.setContents(new StringSelection(encodeTrail), null);
+		JOptionPane.showMessageDialog(this, "Trail copied to clipboard!");
+	}
 
+	private void saveTrailToConfig(String encodeTrail)
+	{
+		config.setConfiguration(PartyTrailsConfig.CONFIG_GROUP, PartyTrailsConfig.BUILDER_STATE, encodeTrail);
+		JOptionPane.showMessageDialog(this, "Trail saved!");
+	}
+
+	private TreasureTrail generateTrailFromBuilderInput()
+	{
+		List<TrailStep> steps = editors.stream()
+			.map(StepEditorPanel::toTrailStep)
+			.collect(Collectors.toList());
+
+		return new TreasureTrail(
+			1,
+			RandomUtil.randomAlphanumeric(16),
+			nameField.getText(),
+			client.getLocalPlayer().getName(),
+			steps
+		);
+	}
+
+	private boolean showValidationErrors()
+	{
+		if (client.getLocalPlayer() == null)
+		{
+			JOptionPane.showMessageDialog(this, "You must be logged in to encode a trail", "Error", JOptionPane.ERROR_MESSAGE);
+			return true;
+		}
+
+		if (nameField.getText().isBlank())
+		{
+			JOptionPane.showMessageDialog(this, "Trail name required", "Error", JOptionPane.ERROR_MESSAGE);
+			return true;
+		}
+
+		if (editors.isEmpty())
+		{
+			JOptionPane.showMessageDialog(this, "Add at least one step", "Error", JOptionPane.ERROR_MESSAGE);
+			return true;
+		}
+
+		String errors = getStepErrors();
+		if (!errors.isBlank())
+		{
+			JOptionPane.showMessageDialog(this, errors, "Error", JOptionPane.ERROR_MESSAGE);
+			return true;
+		}
+
+		return false;
+	}
+
+	private String getStepErrors()
+	{
+		return editors.stream()
+			.flatMap(editor -> editor.getValidationErrors().stream())
+			.sorted(Comparator.comparingInt(StepEditorValidationError::getStepIndex))
+			.map(error -> String.format("Step %d: %s", error.getStepIndex(), error.getErrorMessage()))
+			.collect(Collectors.joining("\n"));
+	}
+
+	private void reloadSave()
+	{
+		TreasureTrail treasureTrail = getSavedTrailFromConfig();
+		if (treasureTrail == null)
+		{
+			return;
+		}
+
+		nameField.setText(treasureTrail.getMetadata().getTrailName());
+		editors.clear();
+		for (int i = 0; i < treasureTrail.getSteps().size(); i++)
+		{
+			StepEditorPanel step = new StepEditorPanel(clueEventBus, this::removeStep, this::updateUI);
+			step.reloadTrailStep(i, treasureTrail.getSteps().get(i));
+			editors.add(step);
+		}
+		rebuildSteps();
+		JOptionPane.showMessageDialog(this, "Successfully loaded save for:\n" + treasureTrail.getMetadata().getTrailName());
+	}
+
+	private TreasureTrail getSavedTrailFromConfig()
+	{
+		String configuredSave = config.getConfiguration(PartyTrailsConfig.CONFIG_GROUP, PartyTrailsConfig.BUILDER_STATE);
+		if (configuredSave == null || configuredSave.isBlank())
+		{
+			JOptionPane.showMessageDialog(this, "No save found in plugin configuration",
+				"Error", JOptionPane.ERROR_MESSAGE);
+			return null;
+		}
+
+		TreasureTrail treasureTrail = null;
+		try
+		{
+			treasureTrail = TrailDecoder.decodeTrail(configuredSave);
+		}
+		catch (Exception e)
+		{
+			JOptionPane.showMessageDialog(this, "Problem encountered while decoding progress: " + e.getMessage(),
+				"Error", JOptionPane.ERROR_MESSAGE);
+			return null;
+		}
+
+		String playerName = client.getLocalPlayer().getName();
+		String trailAuthor = treasureTrail.getMetadata().getAuthor();
+		if (!trailAuthor.equals(playerName))
+		{
+			JOptionPane.showMessageDialog(this, "You can only reload trails that belong to your account!",
+				"Warning", JOptionPane.ERROR_MESSAGE);
+			return null;
+		}
+		return treasureTrail;
+	}
+
+	private JScrollPane createForm()
+	{
+		JPanel form = new JPanel();
+		form.setLayout(new BoxLayout(form, BoxLayout.Y_AXIS));
+
+		addMetadataSection(form);
+		addStepsSection(form);
+		addButtons(form);
+
+		// Start with a single step already present!
+		addStep();
+
+		JScrollPane scrollPane = new JScrollPane(form);
+		scrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+
+		return scrollPane;
+	}
 }

--- a/src/main/java/dev/hollink/partytrails/builder/editors/CoordinateStepEditor.java
+++ b/src/main/java/dev/hollink/partytrails/builder/editors/CoordinateStepEditor.java
@@ -9,9 +9,11 @@ import dev.hollink.partytrails.data.steps.TrailStep;
 import dev.hollink.partytrails.utils.SextantUtil;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.gameval.AnimationID;
 
+@Slf4j
 public final class CoordinateStepEditor extends StepEditor implements FormHelper
 {
 	private final LocationSelector locationSelector = new LocationSelector();
@@ -73,5 +75,18 @@ public final class CoordinateStepEditor extends StepEditor implements FormHelper
 	protected void updateButtonText()
 	{
 		captureButton.setText("Dig to set location!");
+	}
+
+	@Override
+	public void setTrailStep(TrailStep trailStep)
+	{
+		if(trailStep instanceof CoordsStep) {
+			CoordsStep coordsStep = (CoordsStep) trailStep;
+			locationSelector.setLocation(coordsStep.getTargetLocation());
+			log.debug("reloaded coordinate step {}", stepNumber);
+			log.debug(coordsStep.toString());
+		}else {
+			log.warn("Unable to set coordinate step values, given step was of type {}", trailStep.type());
+		}
 	}
 }

--- a/src/main/java/dev/hollink/partytrails/builder/editors/EmoteStepEditor.java
+++ b/src/main/java/dev/hollink/partytrails/builder/editors/EmoteStepEditor.java
@@ -18,7 +18,7 @@ import net.runelite.api.coords.WorldPoint;
 public final class EmoteStepEditor extends StepEditor implements FormHelper
 {
 	private final JComboBox<Emote> emoteIdField = new JComboBox<>(Emote.values());
-	private final JTextArea hintArea = new JTextArea(3, 0);
+	private final JTextArea hintArea = createTextArea();
 	private final LocationSelector locationSelector = new LocationSelector();
 
 	@Override
@@ -78,5 +78,23 @@ public final class EmoteStepEditor extends StepEditor implements FormHelper
 	protected void updateButtonText()
 	{
 		captureButton.setText("Perform emote to set values!");
+	}
+
+	@Override
+	public void setTrailStep(TrailStep trailStep)
+	{
+		if (trailStep instanceof EmoteStep)
+		{
+			EmoteStep emoteStep = (EmoteStep) trailStep;
+			emoteIdField.setSelectedItem(emoteStep.getTargetEmoteOne());
+			hintArea.setText(emoteStep.getHint());
+			locationSelector.setLocation(emoteStep.getTargetLocation());
+			log.debug("reloaded emote step {}", stepNumber);
+			log.debug(emoteStep.toString());
+		}
+		else
+		{
+			log.warn("Unable to set emote step values, given step was of type {}", trailStep.type());
+		}
 	}
 }

--- a/src/main/java/dev/hollink/partytrails/builder/editors/InteractionStepEditor.java
+++ b/src/main/java/dev/hollink/partytrails/builder/editors/InteractionStepEditor.java
@@ -13,11 +13,13 @@ import java.util.List;
 import java.util.stream.Stream;
 import javax.swing.JTextArea;
 import javax.swing.JTextField;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.coords.WorldPoint;
 
+@Slf4j
 public final class InteractionStepEditor extends StepEditor implements FormHelper
 {
-	private final JTextArea hintArea = new JTextArea(3, 0);
+	private final JTextArea hintArea = createTextArea();
 	private final JTextField objectId = new JTextField();
 	private final JTextField objectName = new JTextField();
 	private final JTextField action = new JTextField();
@@ -105,5 +107,23 @@ public final class InteractionStepEditor extends StepEditor implements FormHelpe
 	{
 		InteractionTarget target = new InteractionTarget(Integer.parseInt(objectId.getText()), objectName.getText(), action.getText(), locationSelector.getWorldLocation());
 		return new InteractionStep(stepType, hintArea.getText(), target);
+	}
+
+	@Override
+	public void setTrailStep(TrailStep trailStep)
+	{
+		if(trailStep instanceof InteractionStep) {
+			InteractionStep interactionStep = (InteractionStep) trailStep;
+			InteractionTarget target = interactionStep.getTarget();
+			hintArea.setText(interactionStep.getHint());
+			objectId.setText(String.valueOf(target.getTargetId()));
+			objectName.setText(String.valueOf(target.getTargetName()));
+			action.setText(String.valueOf(target.getInteractionType()));
+			locationSelector.setLocation(target.getLocation());
+			log.debug("reloaded interaction step {}", stepNumber);
+			log.debug(interactionStep.toString());
+		} else {
+			log.warn("Unable to set interaction step values, given step was of type {}", trailStep.type());
+		}
 	}
 }

--- a/src/main/java/dev/hollink/partytrails/builder/editors/SkillStepEditor.java
+++ b/src/main/java/dev/hollink/partytrails/builder/editors/SkillStepEditor.java
@@ -11,14 +11,16 @@ import java.util.List;
 import javax.swing.JComboBox;
 import javax.swing.JTextArea;
 import javax.swing.JTextField;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Skill;
 import net.runelite.api.coords.WorldArea;
 import net.runelite.api.gameval.AnimationID;
 
+@Slf4j
 public final class SkillStepEditor extends StepEditor implements FormHelper
 {
 	private final JComboBox<Skill> skillIdField = new JComboBox<>(Skill.values());
-	private final JTextArea hint = new JTextArea(3, 0);
+	private final JTextArea hint = createTextArea();
 	private final JTextField expField = new JTextField();
 	private final RegionSelector regionSelector = new RegionSelector();
 
@@ -129,5 +131,24 @@ public final class SkillStepEditor extends StepEditor implements FormHelper
 	{
 		captureMode = false;
 		captureButton.setText("Capture region in game");
+	}
+
+	@Override
+	public void setTrailStep(TrailStep trailStep)
+	{
+		if (trailStep instanceof SkillStep)
+		{
+			SkillStep skillStep = (SkillStep) trailStep;
+			hint.setText(skillStep.getHint());
+			skillIdField.setSelectedItem(skillStep.getSkill());
+			expField.setText(String.valueOf(skillStep.getExpRequired()));
+			regionSelector.setWorldArea(skillStep.getArea());
+			log.debug("reloaded skill step {}", stepNumber);
+			log.debug(skillStep.toString());
+		}
+		else
+		{
+			log.warn("Unable to set skill step values, given step was of type {}", trailStep.type());
+		}
 	}
 }

--- a/src/main/java/dev/hollink/partytrails/builder/editors/StepEditor.java
+++ b/src/main/java/dev/hollink/partytrails/builder/editors/StepEditor.java
@@ -8,6 +8,7 @@ import java.util.List;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JPanel;
+import javax.swing.JTextArea;
 import javax.swing.JToolTip;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -66,4 +67,16 @@ public abstract class StepEditor extends JPanel
 	public abstract List<StepEditorValidationError> validateUserInput();
 
 	public abstract TrailStep toTrailStep();
-}
+
+	public abstract void setTrailStep(TrailStep trailStep);
+
+	protected JTextArea createTextArea() {
+		JTextArea textArea = new JTextArea(3, 0);
+
+		textArea.setMaximumSize(new Dimension(220, textArea.getPreferredSize().height));
+		textArea.setLineWrap(true);
+		textArea.setWrapStyleWord(true);
+
+		return textArea;
+	}
+  }

--- a/src/main/java/dev/hollink/partytrails/builder/fields/RegionSelector.java
+++ b/src/main/java/dev/hollink/partytrails/builder/fields/RegionSelector.java
@@ -160,4 +160,13 @@ public final class RegionSelector extends JPanel
 
 		return true;
 	}
+
+	public void setWorldArea(WorldArea area)
+	{
+		xField.setText(String.valueOf(area.getX()));
+		yField.setText(String.valueOf(area.getY()));
+		planeField.setText(String.valueOf(area.getPlane()));
+		widthField.setText(String.valueOf(area.getWidth()));
+		heightField.setText(String.valueOf(area.getHeight()));
+	}
 }

--- a/src/main/java/dev/hollink/partytrails/data/steps/CoordsStep.java
+++ b/src/main/java/dev/hollink/partytrails/data/steps/CoordsStep.java
@@ -11,6 +11,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import net.runelite.api.coords.WorldPoint;
@@ -19,6 +20,7 @@ import net.runelite.client.ui.overlay.components.PanelComponent;
 
 @ToString
 @EqualsAndHashCode
+@Getter
 @RequiredArgsConstructor
 public final class CoordsStep implements TrailStep
 {

--- a/src/main/java/dev/hollink/partytrails/data/steps/EmoteStep.java
+++ b/src/main/java/dev/hollink/partytrails/data/steps/EmoteStep.java
@@ -13,12 +13,14 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.ui.overlay.components.PanelComponent;
 
 @ToString
+@Getter
 @EqualsAndHashCode
 @RequiredArgsConstructor
 public final class EmoteStep implements TrailStep

--- a/src/main/java/dev/hollink/partytrails/data/steps/InteractionStep.java
+++ b/src/main/java/dev/hollink/partytrails/data/steps/InteractionStep.java
@@ -14,12 +14,14 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.List;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.ui.overlay.components.PanelComponent;
 
 @Slf4j
+@Getter
 @ToString
 @EqualsAndHashCode
 public final class InteractionStep implements TrailStep

--- a/src/main/java/dev/hollink/partytrails/data/steps/SkillStep.java
+++ b/src/main/java/dev/hollink/partytrails/data/steps/SkillStep.java
@@ -11,6 +11,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.Objects;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import net.runelite.api.Skill;
@@ -18,6 +19,7 @@ import net.runelite.api.coords.WorldArea;
 import net.runelite.client.ui.overlay.components.PanelComponent;
 
 @ToString
+@Getter
 @RequiredArgsConstructor
 public final class SkillStep implements TrailStep
 {

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -48,9 +48,11 @@
 		</encoder>
 	</appender>
 
-	<root level="INFO">
+	<logger name="dev.hollink.bankstanding" level="DEBUG" />
+	<logger name="net.runelite" level="WARN"/>
+	<logger name="injected-client" level="WARN"/>
+	<root level="WARN">
 		<appender-ref ref="STDOUT"/>
 		<appender-ref ref="FILE"/>
 	</root>
-	<logger name="com.example" level="DEBUG"/>
 </configuration>


### PR DESCRIPTION
## Summary
This PR is meant to help building trails. It adds a save button & and configuration field to store and reload the progress made while building a clue trail. It checks the author name when reloading a trail in the builder to make sure it only loads trails you made yourself.

## Type of Change
- [ ] Bug fix
- [x] Feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation

## Related Issue
Closes #1 

## Testing
How was this tested?
- [x] Manual in-game testing
- [ ] Edge cases tested
- [ ] Verified with different configs

## Screenshots / GIF
If UI or overlay related.

## Checklist
- [x] Code follows RuneLite conventions
- [x] No unnecessary object allocations in hot paths
- [x] Overlay rendering optimized
- [x] No breaking config changes